### PR TITLE
Bugfix for the numeric column declared by UNSIGNED / ZEROFILL keyword would cause parsing mismatches

### DIFF
--- a/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
+++ b/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
@@ -112,6 +112,15 @@ public class MySqlDriver extends AbstractJdbcDriver {
                             ? String.format(" DEFAULT '%s'", dv.isEmpty() ? "''" : dv)
                             : String.format("%s NULL ", !column.isNullable() ? " NOT " : "");
 
+                    // Avoid parsing mismatches when the numeric data type column declared by UNSIGNED / ZEROFILL keyword
+                    String columnType = column.getType();
+                    if (columnType.contains("unsigned") || columnType.contains("zerofill")) {
+                        String[] arr = columnType.split(" ");
+                        arr[0] = arr[0].concat(unit);
+                        columnType = String.join(" ", arr);
+                        unit = "";
+                    }
+
                     return String.format(
                             "  `%s`  %s%s%s%s%s",
                             column.getName(),


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
